### PR TITLE
feat: datepicker get only year and month in LoanApp

### DIFF
--- a/src/pages/LoanApplication.tsx
+++ b/src/pages/LoanApplication.tsx
@@ -92,7 +92,7 @@ const CreditInput = styled(HalfInput)`
 
 const LoanApplication = () => {
   const [stage, setStage] = useState(1);
-  const [startDate, setStartDate] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
 
   //dropdown
   const [selectedJob, setSelectedJob] = useState('');
@@ -137,14 +137,14 @@ const LoanApplication = () => {
         onChange={handleEmploymentChange}
       />
 
-      {/* 월까지만 받도록 수정 */}
       <p>입사년월</p>
       <SelectDate
-        selected={startDate}
-        onChange={(date: Date) => setStartDate(date)}
-        dateFormat="yyyy-MM-dd"
+        selected={selectedDate}
+        onChange={(date: Date) => setSelectedDate(date)}
+        dateFormat="yyyy년 MM월"
         popperPlacement="bottom"
         showPopperArrow={false}
+        showMonthYearPicker
       />
 
       <p>학력</p>


### PR DESCRIPTION
<!--PR 날릴 때 추가사항이랑 변경사항 적어주기~!-->
<!--컴포넌트 생성했으면 그에대한 간략한 설명 (props뭔지, 역할 등)-->

## ✨추가사항✨

<!--추가한 페이지, 컴포넌트-->
loan application 페이지의 입사년월 datepicker에서 년,월만 받을수 있도록 수정함.

✅ 추가내용

> 필요시 부가설명

## ✨변경사항✨

<!--기존에서 컴포넌트로 뺐다거나,, 뭐 그런거-->

✅

>

## 🤔 PR Point

<!--잘 모르겠거나 같이 봤으면 하는 코드있으면 적어주기-->
